### PR TITLE
Add GnuPG to facilitate gpg based request signing

### DIFF
--- a/alpine.Dockerfile
+++ b/alpine.Dockerfile
@@ -39,8 +39,8 @@ RUN apk add -q --update --progress --no-cache ca-certificates
 RUN apk add -q --update --progress --no-cache tzdata
 ENV TZ=
 
-# Setup Git and SSH
-RUN apk add -q --update --progress --no-cache git mandoc git-doc openssh-client
+# Setup Git and SSH and GPG
+RUN apk add -q --update --progress --no-cache git mandoc git-doc openssh-client gnupg
 COPY .ssh.sh /root/
 RUN chmod +x /root/.ssh.sh
 # Retro-compatibility symlink

--- a/debian.Dockerfile
+++ b/debian.Dockerfile
@@ -43,14 +43,14 @@ RUN apt-get update -y && \
     rm -r /var/cache/* /var/lib/apt/lists/*
 ENV TZ=
 
-# Setup Git and SSH
+# Setup Git and SSH and GPG
 # Workaround for older Debian in order to be able to sign commits
 RUN echo "deb https://deb.debian.org/debian bookworm main" >> /etc/apt/sources.list && \
     apt-get update && \
     apt-get install -y --no-install-recommends -t bookworm git git-man && \
     rm -r /var/cache/* /var/lib/apt/lists/*
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends man openssh-client less && \
+    apt-get install -y --no-install-recommends man openssh-client less gpg && \
     rm -r /var/cache/* /var/lib/apt/lists/*
 COPY .ssh.sh /root/
 RUN chmod +x /root/.ssh.sh


### PR DESCRIPTION
## Alpine

### Build

```sh
[~/repos/basedevcontainer]$ docker build -t bdc.alp -f alpine.Dockerfile .                                      *[shwoop-gpg] 
[+] Building 0.5s (44/44) FINISHED                                                                        docker:desktop-linux
 => [internal] load build definition from alpine.Dockerfile                                                               0.0s
 => => transferring dockerfile: 3.31kB                                                                                    0.0s
 => [internal] load metadata for ghcr.io/qdm12/binpot:compose-v2.39.2                                                     0.3s
 => [internal] load metadata for ghcr.io/qdm12/binpot:bit-v1.1.2                                                          0.3s
 => [internal] load metadata for ghcr.io/qdm12/binpot:buildx-v0.26.1                                                      0.4s
 => [internal] load metadata for ghcr.io/qdm12/binpot:gh-v2.76.2                                                          0.4s
 => [internal] load metadata for ghcr.io/qdm12/binpot:logo-ls-v1.3.7                                                      0.4s
 => [internal] load metadata for ghcr.io/qdm12/devtainr:v0.7.0                                                            0.3s
 => [internal] load metadata for docker.io/library/alpine:3.22                                                            0.3s
 => [internal] load metadata for ghcr.io/qdm12/binpot:docker-v28.2.2                                                      0.4s
 => [internal] load .dockerignore                                                                                         0.0s
 => => transferring context: 164B                                                                                         0.0s
 => [stage-7  1/25] FROM docker.io/library/alpine:3.22@sha256:4bcff63911fcb4448bd4fdacec207030997caf25e9bea4045fa6c8c44d  0.0s
 => [compose 1/1] FROM ghcr.io/qdm12/binpot:compose-v2.39.2@sha256:2e389e363b1b4a69e55508f35eafc480ae9130d5a5efda51a1831  0.0s
 => [docker 1/1] FROM ghcr.io/qdm12/binpot:docker-v28.2.2@sha256:2f50e6505b355a043152aa6e20b330a5b0b6bc799aa1736b719501e  0.0s
 => [devtainr 1/1] FROM ghcr.io/qdm12/devtainr:v0.7.0@sha256:884b0a6ef42a9bac60c27647743d2e54637be1a5a745a735c3dac726ced  0.0s
 => [bit 1/1] FROM ghcr.io/qdm12/binpot:bit-v1.1.2@sha256:e77ad72469ca2f0fa4f0fb94415a86d58200129cc536622f1d38272b681f44  0.0s
 => [logo-ls 1/1] FROM ghcr.io/qdm12/binpot:logo-ls-v1.3.7@sha256:6f0756cca7b50b5f835925b918da21cfb4c716fac428b801ad8651  0.0s
 => [internal] load build context                                                                                         0.0s
 => => transferring context: 158B                                                                                         0.0s
 => [buildx 1/1] FROM ghcr.io/qdm12/binpot:buildx-v0.26.1@sha256:4fcc78f99d006f2356010d63200d4ae9bbd54931101a4e894a1a90e  0.0s
 => [gh 1/1] FROM ghcr.io/qdm12/binpot:gh-v2.76.2@sha256:d0e69628f23214b7f28583fbad619e966e4fad0234bee0b0d4b882b80b405aa  0.0s
 => CACHED [stage-7  2/25] RUN apk add -q --update --progress --no-cache ca-certificates                                  0.0s
 => CACHED [stage-7  3/25] RUN apk add -q --update --progress --no-cache tzdata                                           0.0s
 => CACHED [stage-7  4/25] RUN apk add -q --update --progress --no-cache git mandoc git-doc openssh-client gnupg          0.0s
 => CACHED [stage-7  5/25] COPY .ssh.sh /root/                                                                            0.0s
 => CACHED [stage-7  6/25] RUN chmod +x /root/.ssh.sh                                                                     0.0s
 => CACHED [stage-7  7/25] RUN ln -s /root/.ssh.sh /root/.windows.sh                                                      0.0s
 => CACHED [stage-7  8/25] WORKDIR /root                                                                                  0.0s
 => CACHED [stage-7  9/25] RUN apk add -q --update --progress --no-cache zsh nano zsh-vcs                                 0.0s
 => CACHED [stage-7 10/25] RUN apk add -q --update --progress --no-cache shadow &&     usermod --shell /bin/zsh root &&   0.0s
 => CACHED [stage-7 11/25] COPY shell/.zshrc shell/.welcome.sh /root/                                                     0.0s
 => CACHED [stage-7 12/25] RUN git clone --single-branch --depth 1 https://github.com/robbyrussell/oh-my-zsh.git ~/.oh-m  0.0s
 => CACHED [stage-7 13/25] COPY shell/.p10k.zsh /root/                                                                    0.0s
 => CACHED [stage-7 14/25] RUN apk add -q --update --progress --no-cache zsh-theme-powerlevel10k gitstatus &&     ln -s   0.0s
 => CACHED [stage-7 15/25] COPY --from=docker /bin /usr/local/bin/docker                                                  0.0s
 => CACHED [stage-7 16/25] COPY --from=compose /bin /usr/libexec/docker/cli-plugins/docker-compose                        0.0s
 => CACHED [stage-7 17/25] RUN echo "alias docker-compose='docker compose'" >> /root/.zshrc                               0.0s
 => CACHED [stage-7 18/25] COPY --from=buildx /bin /usr/libexec/docker/cli-plugins/docker-buildx                          0.0s
 => CACHED [stage-7 19/25] COPY --from=logo-ls /bin /usr/local/bin/logo-ls                                                0.0s
 => CACHED [stage-7 20/25] RUN echo "alias ls='logo-ls'" >> /root/.zshrc                                                  0.0s
 => CACHED [stage-7 21/25] COPY --from=bit /bin /usr/local/bin/bit                                                        0.0s
 => CACHED [stage-7 22/25] RUN if [ "linux/arm64" != "linux/s390x" ]; then echo "y" | bit complete; fi                    0.0s
 => CACHED [stage-7 23/25] COPY --from=gh /bin /usr/local/bin/gh                                                          0.0s
 => CACHED [stage-7 24/25] COPY --from=devtainr /devtainr /usr/local/bin/devtainr                                         0.0s
 => CACHED [stage-7 25/25] RUN apk add -q --update --progress --no-cache libstdc++                                        0.0s
 => exporting to image                                                                                                    0.0s
 => => exporting layers                                                                                                   0.0s
 => => writing image sha256:40c351b1aab65f767f2ccb9304055278ed8d227985b88c2480c305b691fda173                              0.0s
 => => naming to docker.io/library/bdc.alp                                                                                0.0s

What's next:
    View a summary of image vulnerabilities and recommendations → docker scout quickview 
```

### Test

```sh
[~/repos/basedevcontainer]$ docker run -it bdc.alp                                                                                                                                                                                 *[shwoop-gpg] 
No bind mounted ssh directory found (~/.ssh, /tmp/.ssh, /mnt/ssh), exiting
[WARNING] No SSH directory found, SSH functionalities might not work
[WARNING] TZ environment variable not set, time might be wrong!
[WARNING] Docker socket not found, docker will not be available

Base version: local--

Terminal Docker tools aliases:
 * alpine: launch an interactive alpine 3.22 container
~ ❯ gpg --version                                                                                                                                                                                                               root@86d8e27f749c
gpg (GnuPG) 2.4.7
libgcrypt 1.10.3
Copyright (C) 2024 g10 Code GmbH
License GNU GPL-3.0-or-later <https://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Home: /root/.gnupg
Supported algorithms:
Pubkey: RSA, ELG, DSA, ECDH, ECDSA, EDDSA
Cipher: IDEA, 3DES, CAST5, BLOWFISH, AES, AES192, AES256, TWOFISH,
        CAMELLIA128, CAMELLIA192, CAMELLIA256
Hash: SHA1, RIPEMD160, SHA256, SHA384, SHA512, SHA224
Compression: Uncompressed, ZIP, ZLIB, BZIP2
```


## Debian

### Build

```sh
[~/repos/basedevcontainer]$ docker build -t bdc.deb -f debian.Dockerfile .                                      *[shwoop-gpg] 
[+] Building 22.2s (44/44) FINISHED                                                                       docker:desktop-linux
 => [internal] load build definition from debian.Dockerfile                                                               0.0s
 => => transferring dockerfile: 4.03kB                                                                                    0.0s
 => [internal] load metadata for docker.io/library/debian:12-slim                                                         0.0s
 => [internal] load metadata for ghcr.io/qdm12/devtainr:v0.7.0                                                            0.6s
 => [internal] load metadata for ghcr.io/qdm12/binpot:bit-v1.1.2                                                          0.6s
 => [internal] load metadata for ghcr.io/qdm12/binpot:buildx-v0.26.1                                                      0.6s
 => [internal] load metadata for ghcr.io/qdm12/binpot:gh-v2.76.2                                                          0.6s
 => [internal] load metadata for ghcr.io/qdm12/binpot:docker-v28.2.2                                                      0.6s
 => [internal] load metadata for ghcr.io/qdm12/binpot:logo-ls-v1.3.7                                                      0.6s
 => [internal] load metadata for ghcr.io/qdm12/binpot:compose-v2.39.2                                                     0.6s
 => [internal] load .dockerignore                                                                                         0.0s
 => => transferring context: 164B                                                                                         0.0s
 => [stage-7  1/25] FROM docker.io/library/debian:12-slim                                                                 0.0s
 => CACHED [compose 1/1] FROM ghcr.io/qdm12/binpot:compose-v2.39.2@sha256:2e389e363b1b4a69e55508f35eafc480ae9130d5a5efda  0.0s
 => [internal] load build context                                                                                         0.0s
 => => transferring context: 158B                                                                                         0.0s
 => CACHED [logo-ls 1/1] FROM ghcr.io/qdm12/binpot:logo-ls-v1.3.7@sha256:6f0756cca7b50b5f835925b918da21cfb4c716fac428b80  0.0s
 => CACHED [docker 1/1] FROM ghcr.io/qdm12/binpot:docker-v28.2.2@sha256:2f50e6505b355a043152aa6e20b330a5b0b6bc799aa1736b  0.0s
 => CACHED [devtainr 1/1] FROM ghcr.io/qdm12/devtainr:v0.7.0@sha256:884b0a6ef42a9bac60c27647743d2e54637be1a5a745a735c3da  0.0s
 => CACHED [gh 1/1] FROM ghcr.io/qdm12/binpot:gh-v2.76.2@sha256:d0e69628f23214b7f28583fbad619e966e4fad0234bee0b0d4b882b8  0.0s
 => CACHED [buildx 1/1] FROM ghcr.io/qdm12/binpot:buildx-v0.26.1@sha256:4fcc78f99d006f2356010d63200d4ae9bbd54931101a4e89  0.0s
 => CACHED [bit 1/1] FROM ghcr.io/qdm12/binpot:bit-v1.1.2@sha256:e77ad72469ca2f0fa4f0fb94415a86d58200129cc536622f1d38272  0.0s
 => [stage-7  2/25] RUN apt-get update -y &&     apt-get install -y --no-install-recommends ca-certificates &&     rm -r  3.3s
 => [stage-7  3/25] RUN apt-get update -y &&     apt-get install -y --no-install-recommends tzdata &&     rm -r /var/cac  2.0s
 => [stage-7  4/25] RUN echo "deb https://deb.debian.org/debian bookworm main" >> /etc/apt/sources.list &&     apt-get u  4.3s 
 => [stage-7  5/25] RUN apt-get update -y &&     apt-get install -y --no-install-recommends man openssh-client less gpg   3.4s 
 => [stage-7  6/25] COPY .ssh.sh /root/                                                                                   0.0s 
 => [stage-7  7/25] RUN chmod +x /root/.ssh.sh                                                                            0.1s 
 => [stage-7  8/25] RUN  ln -s /root/.ssh.sh /root/.windows.sh                                                            0.1s 
 => [stage-7  9/25] RUN apt-get update -y &&     apt-get install -y --no-install-recommends zsh nano locales wget &&      4.2s 
 => [stage-7 10/25] RUN echo "LC_ALL=en_US.UTF-8" >> /etc/environment &&     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen  0.9s 
 => [stage-7 11/25] RUN usermod --shell /bin/zsh root                                                                     0.1s 
 => [stage-7 12/25] COPY shell/.zshrc shell/.welcome.sh /root/                                                            0.0s 
 => [stage-7 13/25] RUN git clone --single-branch --depth 1 https://github.com/robbyrussell/oh-my-zsh.git ~/.oh-my-zsh    1.0s 
 => [stage-7 14/25] COPY shell/.p10k.zsh /root/                                                                           0.0s 
 => [stage-7 15/25] RUN git clone --branch v1.16.1 --single-branch --depth 1 https://github.com/romkatv/powerlevel10k.gi  0.8s 
 => [stage-7 16/25] COPY --from=docker /bin /usr/local/bin/docker                                                         0.1s
 => [stage-7 17/25] COPY --from=compose /bin /usr/libexec/docker/cli-plugins/docker-compose                               0.1s
 => [stage-7 18/25] RUN echo "alias docker-compose='docker compose'" >> /root/.zshrc                                      0.1s 
 => [stage-7 19/25] COPY --from=buildx /bin /usr/libexec/docker/cli-plugins/docker-buildx                                 0.2s 
 => [stage-7 20/25] COPY --from=logo-ls /bin /usr/local/bin/logo-ls                                                       0.0s 
 => [stage-7 21/25] RUN echo "alias ls='logo-ls'" >> /root/.zshrc                                                         0.1s 
 => [stage-7 22/25] COPY --from=bit /bin /usr/local/bin/bit                                                               0.1s
 => [stage-7 23/25] RUN if [ "linux/arm64" != "linux/s390x" ]; then echo "y" | bit complete; fi                           0.1s
 => [stage-7 24/25] COPY --from=gh /bin /usr/local/bin/gh                                                                 0.1s
 => [stage-7 25/25] COPY --from=devtainr /devtainr /usr/local/bin/devtainr                                                0.0s
 => exporting to image                                                                                                    0.4s
 => => exporting layers                                                                                                   0.4s
 => => writing image sha256:08c340bae090d8b7c79c1358900f69527d78da32cbf954eea8ad18ab5833285e                              0.0s
 => => naming to docker.io/library/bdc.deb                                                                                0.0s

What's next:
    View a summary of image vulnerabilities and recommendations → docker scout quickview 
```

### Test

```sh
[~/repos/basedevcontainer]$ docker run -it bdc.deb                                                 *[shwoop-gpg] 
No bind mounted ssh directory found (~/.ssh, /tmp/.ssh, /mnt/ssh), exiting
[WARNING] No SSH directory found, SSH functionalities might not work
[WARNING] TZ environment variable not set, time might be wrong!
[WARNING] Docker socket not found, docker will not be available

Base version: local--

Terminal Docker tools aliases:
 * alpine: launch an interactive alpine 3.22 container
[powerlevel10k] fetching gitstatusd .. [ok]                                                                       
/ ❯ gpg --version                                                                               root@68c7a4ded67a
gpg (GnuPG) 2.2.40
libgcrypt 1.10.1
Copyright (C) 2022 g10 Code GmbH
License GNU GPL-3.0-or-later <https://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Home: /root/.gnupg
Supported algorithms:
Pubkey: RSA, ELG, DSA, ECDH, ECDSA, EDDSA
Cipher: IDEA, 3DES, CAST5, BLOWFISH, AES, AES192, AES256, TWOFISH,
        CAMELLIA128, CAMELLIA192, CAMELLIA256
Hash: SHA1, RIPEMD160, SHA256, SHA384, SHA512, SHA224
Compression: Uncompressed, ZIP, ZLIB, BZIP2
/ ❯                                                                                             root@68c7a4ded67a
```